### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,10 +69,11 @@ export class Sigma {
       throw new Error("Input hash and data hash must be set");
     }
 
-    const combinedHashes = new Uint8Array([
-      ...this._inputHash.to_bytes(),
-      ...this._dataHash.to_bytes(),
-    ]);
+    const inputBytes = this._inputHash.to_bytes();
+    const dataBytes = this._dataHash.to_bytes();
+    const combinedHashes = new Uint8Array(inputBytes.length + dataBytes.length);
+    combinedHashes.set(inputBytes, 0);
+    combinedHashes.set(dataBytes, inputBytes.length);
 
     return Hash.sha_256(combinedHashes);
   }


### PR DESCRIPTION
This change replaces the use of the spread operator in Uint8Array instantiation to concatenate bytes from _inputHash and _dataHash. The spread operator is not compatible with TypeScript's target of es5, causing a compile-time error. To resolve this, we now use the set method of Uint8Array to manually copy the bytes from _inputHash and _dataHash into combinedHashes.