### PR TITLE
Pass tests by adding required param to method in index.test.ts

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -243,7 +243,8 @@ describe("Sigma Protocol", () => {
     const result = await sigma.remoteSign("http://localhost:21000", {
       key: "Authorization",
       value: "Bearer mockToken",
-    } as AuthToken);
+      type: 'header'
+    });
 
     console.log({ result });
     // Check the result


### PR DESCRIPTION
Now `npm test` passes directly off of an initial download