### PR TITLE
Bind BRC-77 signer identity to Sigma address

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -275,6 +275,24 @@ describe("Sigma Protocol", () => {
     assert.strictEqual(isValid, true);
   });
 
+  it("rejects BRC-77 when the envelope signer does not match the claimed address", () => {
+    const tx = new Transaction(1, [], [txOut]);
+    const sigma = new Sigma(tx, 0, 0);
+    const { signedTx } = sigma.sign(privateKey, Algorithm.BRC77);
+
+    const asmChunks = signedTx.outputs[0].lockingScript.toASM().split(" ");
+    const sigmaIndex = asmChunks.indexOf(toHex(toArray("SIGMA")));
+    assert.notStrictEqual(sigmaIndex, -1);
+
+    const claimedAddress = privateKey2.toAddress();
+    asmChunks[sigmaIndex + 2] = toHex(toArray(claimedAddress));
+    signedTx.outputs[0].lockingScript = Script.fromASM(asmChunks.join(" "));
+
+    const tamperedSigma = new Sigma(signedTx);
+    assert.strictEqual(tamperedSigma.sig?.address, claimedAddress);
+    assert.strictEqual(tamperedSigma.verify(), false);
+  });
+
   it("supports mixed BSM and BRC-77 signatures on same output", () => {
     const tx = new Transaction(1, [], [txOut]);
     const sigma = new Sigma(tx, 0, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import {
 	BSM,
 	Hash,
 	type PrivateKey,
-	type PublicKey,
+	PublicKey,
 	Script,
 	Signature,
 	SignedMessage,
@@ -412,7 +412,14 @@ export class Sigma {
 		if (this.sig.algorithm === Algorithm.BRC77) {
 			// BRC-77 verification
 			const sigBytes = toArray(this.sig.signature, "base64");
-			return SignedMessage.verify(msgHash, sigBytes, recipientPrivateKey);
+			if (!SignedMessage.verify(msgHash, sigBytes, recipientPrivateKey)) {
+				return false;
+			}
+
+			// BRC-77 serializes the signer's 33-byte identity public key
+			// immediately after its 4-byte version field.
+			const signerPublicKey = PublicKey.fromDER(sigBytes.slice(4, 37));
+			return signerPublicKey.toAddress() === this.sig.address;
 		}
 
 		// BSM verification


### PR DESCRIPTION
Fixes #11

## Summary
- verify the BRC-77 envelope before inspecting its signer identity key
- derive the signer P2PKH address from the embedded 33-byte public key
- reject signatures when that derived address differs from the Sigma address field
- add a regression test that tampers only the claimed address

## Test-first evidence
The regression test failed before the production change with true !== false, demonstrating that the tampered tape was accepted. It passes after the binding check.

## Verification
- bun test: 12 passed, 0 failed
- bun run build: passed
- git diff --check: passed